### PR TITLE
Add sort statement abstraction

### DIFF
--- a/src/Aggregations/TopHitsAggregation.php
+++ b/src/Aggregations/TopHitsAggregation.php
@@ -2,7 +2,7 @@
 
 namespace Everzel\ElasticsearchQueryBuilder\Aggregations;
 
-use Everzel\ElasticsearchQueryBuilder\Sorts\Sort;
+use Everzel\ElasticsearchQueryBuilder\Sorts\SortInterface as Sort;
 
 class TopHitsAggregation extends Aggregation
 {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,7 +6,7 @@ use Elasticsearch\Client;
 use Everzel\ElasticsearchQueryBuilder\Aggregations\Aggregation;
 use Everzel\ElasticsearchQueryBuilder\Queries\BoolQuery;
 use Everzel\ElasticsearchQueryBuilder\Queries\Query;
-use Everzel\ElasticsearchQueryBuilder\Sorts\Sort;
+use Everzel\ElasticsearchQueryBuilder\Sorts\SortInterface as Sort;
 
 class Builder
 {

--- a/src/SortCollection.php
+++ b/src/SortCollection.php
@@ -2,7 +2,7 @@
 
 namespace Everzel\ElasticsearchQueryBuilder;
 
-use Everzel\ElasticsearchQueryBuilder\Sorts\Sort;
+use Everzel\ElasticsearchQueryBuilder\Sorts\SortInterface as Sort;
 
 class SortCollection
 {

--- a/src/Sorts/Sort.php
+++ b/src/Sorts/Sort.php
@@ -2,7 +2,7 @@
 
 namespace Everzel\ElasticsearchQueryBuilder\Sorts;
 
-class Sort
+class Sort implements SortInterface
 {
     public const ASC = 'asc';
     public const DESC = 'desc';

--- a/src/Sorts/SortInterface.php
+++ b/src/Sorts/SortInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Everzel\ElasticsearchQueryBuilder\Sorts;
+
+interface SortInterface
+{
+    public function toArray(): array;
+}


### PR DESCRIPTION
**Problem:** there's not possibility to create custom sort query class and pass it to query builder

**Solution:**

The changes should enable to create their own sort classes:

```php
class SequentialSort implements SortInterface
{
    // some logic...
    public function toArray(): array
    {
        ...
    }
}

// usage code
$esQuery->addSort(SequentialSort::create($field, $order));
```